### PR TITLE
Fix srcDir for precompiling AST Transformations

### DIFF
--- a/scripts/_Events.groovy
+++ b/scripts/_Events.groovy
@@ -1,5 +1,5 @@
 eventCompileStart = { target ->
-    compileAST(pluginBaseDir, classesDirPath)
+    compileAST(postgresqlExtensionsPluginDir, classesDirPath)
 }
 
 def compileAST(def srcBaseDir, def destDir) {


### PR DESCRIPTION
Using Grails 2.2.4, compileAST tried to compile in the application instead of the plugin. This is fixed using pluginBaseDir instead of basedir
