### PR TITLE
Fixing enum array mapping issues

### DIFF
--- a/grails-app/domain/test/array/TestEnum.groovy
+++ b/grails-app/domain/test/array/TestEnum.groovy
@@ -13,8 +13,8 @@ class TestEnum {
         SATURDAY(5),
         SUNDAY(6)
 
-        private final int value
-        Day(int value)  { this.value = value }
+        final int id
+        Day(int id)  { this.id = id }
     }
 
     Day[] days

--- a/grails-app/domain/test/criteria/array/Like.groovy
+++ b/grails-app/domain/test/criteria/array/Like.groovy
@@ -24,8 +24,8 @@ class Like {
         CARROT(7),
         LEMON(8)
 
-        private final int value
-        Juice(int value)  { this.value = value }
+        private final int id
+        Juice(int id)  { this.id = id }
     }
 
     static mapping = {

--- a/src/java/net/kaleidos/hibernate/usertype/ArrayType.java
+++ b/src/java/net/kaleidos/hibernate/usertype/ArrayType.java
@@ -7,10 +7,7 @@ import org.hibernate.usertype.ParameterizedType;
 import org.hibernate.usertype.UserType;
 
 import java.io.Serializable;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Types;
+import java.sql.*;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -101,18 +98,19 @@ public class ArrayType implements UserType, ParameterizedType {
 
     @Override
     public Object nullSafeGet(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws HibernateException, SQLException {
-        Object[] result = null;
+        Object result = null;
         Class typeArrayClass = java.lang.reflect.Array.newInstance(typeClass, 0).getClass();
-        java.sql.Array array = rs.getArray(names[0]);
+        Array sqlArray = rs.getArray(names[0]);
         if (!rs.wasNull()) {
+            Object array = sqlArray.getArray();
             if (typeClass.isEnum()) {
-                int length = java.lang.reflect.Array.getLength(array);
-                Object converted = java.lang.reflect.Array.newInstance(typeClass, length);
+                int length = array != null ? java.lang.reflect.Array.getLength(array) : 0;
+                result = java.lang.reflect.Array.newInstance(typeClass, length);
                 for (int i = 0; i < length; i++) {
-                    java.lang.reflect.Array.set(converted, i, idToEnum(java.lang.reflect.Array.get(array, i)));
+                    java.lang.reflect.Array.set(result, i, idToEnum((Integer)java.lang.reflect.Array.get(array, i)));
                 }
             } else {
-                result = (Object[]) typeArrayClass.cast(array.getArray());
+                result = typeArrayClass.cast(array);
             }
         }
         return result;
@@ -136,7 +134,7 @@ public class ArrayType implements UserType, ParameterizedType {
                 if (valueToSet[i] instanceof Integer) {
                     converted[i] = (Integer) valueToSet[i];
                 } else {
-                    converted[i] = ((Enum) valueToSet[i]).ordinal();
+                    converted[i] = enumToId(valueToSet[i]);
                 }
             }
             valueToSet = converted;
@@ -150,14 +148,22 @@ public class ArrayType implements UserType, ParameterizedType {
         return typeClass;
     }
 
-    private Object idToEnum(Object id) throws HibernateException {
+    private void ensureBidiMapInitialized() throws HibernateException {
         try {
-            if (bidiMap == null) {
+            if (bidiMap == null)
                 bidiMap = new BidiEnumMap(typeClass);
-            }
-            return bidiMap.getEnumValue(id);
         } catch (Exception e) {
             throw new HibernateException("Unable to create bidirectional enum map for " + typeClass, e);
         }
+    }
+
+    private Object idToEnum(int id) throws HibernateException {
+        ensureBidiMapInitialized();
+        return bidiMap.getEnumValue(id);
+    }
+
+    private int enumToId(Object enumValue) throws HibernateException {
+        ensureBidiMapInitialized();
+        return bidiMap.getKey(enumValue);
     }
 }

--- a/src/java/net/kaleidos/hibernate/usertype/BidiEnumMap.java
+++ b/src/java/net/kaleidos/hibernate/usertype/BidiEnumMap.java
@@ -29,7 +29,7 @@ public class BidiEnumMap implements Serializable {
         EnumMap enumToKey = new EnumMap(enumClass);
         HashMap keytoEnum = new HashMap();
 
-        Method idAccessor = enumClass.getMethod(ENUM_ID_ACCESSOR);
+        Method idAccessor = getIdAccessor(enumClass);
 
         Method valuesAccessor = enumClass.getMethod("values");
         Object[] values = (Object[]) valuesAccessor.invoke(enumClass);
@@ -47,11 +47,18 @@ public class BidiEnumMap implements Serializable {
         this.keytoEnum = Collections.unmodifiableMap(keytoEnum);
     }
 
-    public Object getEnumValue(Object id) {
+    private Method getIdAccessor(Class<?> enumClass) throws NoSuchMethodException {
+        for (Method method : enumClass.getMethods())
+            if (method.getName().equals(ENUM_ID_ACCESSOR))
+                return method;
+        return enumClass.getMethod("ordinal");
+    }
+
+    public Object getEnumValue(int id) {
         return keytoEnum.get(id);
     }
 
-    public Object getKey(Object enumValue) {
-        return enumToKey.get(enumValue);
+    public int getKey(Object enumValue) {
+        return (Integer)enumToKey.get(enumValue);
     }
 }

--- a/src/java/net/kaleidos/hibernate/usertype/JsonMapType.java
+++ b/src/java/net/kaleidos/hibernate/usertype/JsonMapType.java
@@ -22,7 +22,7 @@ public class JsonMapType implements UserType {
 
     private final Type userType = Map.class;
 
-    private final Gson gson = new GsonBuilder().create();
+    private final Gson gson = new GsonBuilder().serializeNulls().create();
 
     @Override
     public int[] sqlTypes() {


### PR DESCRIPTION
Fixed exception:
```
Argument is not an array
java.lang.IllegalArgumentException: Argument is not an array
    at net.kaleidos.hibernate.usertype.ArrayType.nullSafeGet(ArrayType.java:109)
    at org.hibernate.type.CustomType.nullSafeGet(CustomType.java:127)
```

Fixed enum to integer mapping issue: `ArrayType.nullSafeGet` expected `getId()` method on enum, but `ArrayType.nullSafeSet` used `ordinal()` result while saving
```
Caused by: java.lang.NoSuchMethodException: test.criteria.array.Like$Juice.getId()
    at java.lang.Class.getMethod(Class.java:1670)
    at net.kaleidos.hibernate.usertype.BidiEnumMap.<init>(BidiEnumMap.java:32)
    at net.kaleidos.hibernate.usertype.ArrayType.idToEnum(ArrayType.java:154)
```
Not plugin will try to use a result of `getId()` method as an identifier or will use `ordinal()` if such method is missing.

The main reason why fixed issues have not been reproduced when running integration tests is that domain saving and retrieving should be in different sessions. Only in that case Hibernate will invoke `nullSafeGet` on the corresponding user type and will not use current session's cache.