### PR TITLE
JsonbMapType reporting their type appropriately

### DIFF
--- a/src/java/net/kaleidos/hibernate/usertype/JsonbMapType.java
+++ b/src/java/net/kaleidos/hibernate/usertype/JsonbMapType.java
@@ -4,4 +4,8 @@ public class JsonbMapType extends JsonMapType {
 
     public static int SQLTYPE = 90022;
 
+    @Override
+    public int[] sqlTypes() {
+        return new int[]{SQLTYPE};
+    }
 }


### PR DESCRIPTION
Use jsonb with a dbCreate='validate'
When using a JsonbMapType class and  `dbCreate='validate'` with the current plugin, the following happens:

`nested exception is org.hibernate.HibernateException: Wrong column type in term.stanson_code for column code. Found: jsonb, expected: json`

This is because the JsonbMapType is a child class of JsonMapType and the `sqlTypes` method is not being overridden correctly.

Here is an example:

Domain Class:
```
    // The key/value json blob
    Map code
    static mapping = {
        code type: JsonbMapType
    }
```

Using update, this will NOT complain that the 'jsonb' and 'json' types do not match. We can see that the JsonbMapType is reporting the wrong type when the schema is exported:

`$> ./grailsw schema-export; cat target/ddl.sql | grep json`


Before:
``` 
code json not null,
```

With the code in the pull requesT:
```
code jsonb not null,
```