### PR TITLE
Fix for #76

### DIFF
--- a/src/java/net/kaleidos/hibernate/usertype/JsonMapType.java
+++ b/src/java/net/kaleidos/hibernate/usertype/JsonMapType.java
@@ -47,7 +47,8 @@ public class JsonMapType implements UserType {
 
     @Override
     public Object nullSafeGet(ResultSet rs, String[] names, SessionImplementor session, Object owner) throws HibernateException, SQLException {
-        String jsonString = ((PGobject)rs.getObject(names[0])).getValue();
+        PGobject o = ((PGobject)rs.getObject(names[0]));
+        String jsonString = o != null ? o.getValue() : null;
         return gson.fromJson(jsonString, userType);
     }
 


### PR DESCRIPTION
Fix for #76

A null value can be stored in the database for a column type Json or Jsonb.

A java.lang.NullPointerException when the value is null.
Added null check
Updated tests