### PR TITLE
fix dirty check for empty hstore

### DIFF
--- a/src/integration-test/groovy/net/kaleidos/hibernate/hstore/PostgresqlHstoreMapDomainIntegrationSpec.groovy
+++ b/src/integration-test/groovy/net/kaleidos/hibernate/hstore/PostgresqlHstoreMapDomainIntegrationSpec.groovy
@@ -93,4 +93,41 @@ class PostgresqlHstoreMapDomainIntegrationSpec extends Specification {
             [foo: "bar"]           | "foo"     | "bar"
             ["foo,bar": "baz,qux"] | "foo,bar" | "baz,qux"
     }
+
+    @Unroll
+    void 'save a domain class with a empty map and validate that is not dirty right after retrieval'() {
+        setup:
+        def testHstoreMap = new TestHstoreMap(testAttributes: [:])
+
+        when: 'I save an instance'
+        testHstoreMap.save()
+
+        and: 'The instance is saved'
+        assert !testHstoreMap.hasErrors()
+
+        and: 'I retrieve it and check for dirty properties'
+        def retrievedTestHstoreMap = testHstoreMap.get(testHstoreMap.id)
+
+        then: 'It shouldn\'t be dirty right after db retrieval'
+        !retrievedTestHstoreMap.isDirty()
+    }
+
+    @Unroll
+    void 'save a domain class, modify it and validate that it\'s dirty'() {
+        setup:
+        def testHstoreMap = new TestHstoreMap(testAttributes: [:])
+
+        when: 'I save an instance'
+        testHstoreMap.save()
+
+        and: 'The instance is saved'
+        assert !testHstoreMap.hasErrors()
+
+        and: 'I retrieve it and modify a property'
+        def retrievedTestHstoreMap = testHstoreMap.get(testHstoreMap.id)
+        retrievedTestHstoreMap.testAttributes << [foo: 'bar']
+
+        then: 'It shouldn be dirty'
+        retrievedTestHstoreMap.isDirty()
+    }
 }

--- a/src/main/groovy/net/kaleidos/hibernate/usertype/HstoreMapType.groovy
+++ b/src/main/groovy/net/kaleidos/hibernate/usertype/HstoreMapType.groovy
@@ -51,7 +51,7 @@ class HstoreMapType implements UserType {
     }
 
     Object deepCopy(Object value) throws HibernateException {
-        value ? new HashMap(value as Map) : null
+        value == null ? null : new HashMap(value as Map)
     }
 
     boolean isMutable() {


### PR DESCRIPTION
for issue https://github.com/kaleidos/grails-postgresql-extensions/issues/96

After debugging hibernate I have found the root cause. Here's a short explanation:

GORM to find dirty properties compares the actual object `instance` with an `entry` (this is I assume is the initial object without any values)
https://github.com/grails/gorm-hibernate5/blob/master/grails-datastore-gorm-hibernate5/src/main/groovy/org/grails/orm/hibernate/HibernateGormInstanceApi.groovy#L53-L61
the crucial thing is here that `def entry = findEntityEntry(instance, session)` method

If you dive deep enough into this method you will end up in `TwoPhaseLoad` class and a line where deepCopy happens:
https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/engine/internal/TwoPhaseLoad.java#L267-L274
the `hydratedState` is an array of all object properties that later on are transformed into `loadedState`. But what's important here is this: `TypeHelper.deepCopy` iterates over all types and when it encounters the UserDefined `HstoreMapType` it uses its `deepCopy` method. 

The main problem here is the groovy truth.
`null` and empty `Map` is not the same when in comes to equals method that's being used by `isDirty` later on (https://github.com/hibernate/hibernate-orm/blob/master/hibernate-core/src/main/java/org/hibernate/type/AbstractType.java#L70-L72). 

Doing  a deepCopy for empty map or `null` will yield the same result: `null`.

Initially Hibernate created an empty map for that hstore type but if you deepCopy it you will get a null. The `isDirty` equal call will fail and hence the object will be dirty

So to fix this we just need to be consistent in deepCopy. Return `null` if it's  a `null` or copy the map even if it's empty.


PS. 
I'm more interested in back-porting this into `v4`. This should be trivial. How should that be done? A PR with cherry-pick?