### PR TITLE
change db credentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ sudo: false
 before_script:
   - psql -d template1 -c 'create extension hstore;' -U postgres
   - psql -c 'create database pg_extensions_test;' -U postgres
-  - psql -c "create user pg_extensions with password 'pg_extensions';" -U postgres
-  - psql -c "grant all privileges on database pg_extensions_test to pg_extensions;" -U postgres
+  - psql -c "create user postgres_extensions with password 'postgres_extensions';" -U postgres
+  - psql -c "grant all privileges on database pg_extensions_test to postgres_extensions;" -U postgres
   - rm -rf target
 
 script:

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -19,8 +19,8 @@ dataSource:
     jmxExport: true
     driverClassName: org.postgresql.Driver
     dialect: net.kaleidos.hibernate.PostgresqlExtensionsDialect
-    username: pg_extensions
-    password: pg_extensions
+    username: postgres_extensions
+    password: postgres_extensions
     url: jdbc:postgresql://localhost/pg_extensions_test
     dbCreate: create
 


### PR DESCRIPTION
In current newest postgresql =  `9.6` (right now) it's not possible to create a role/user starting with prefix `pg_`

```
psql~: create role pg_extensions;
ERROR:  role name "pg_extensions" is reserved
DETAIL:  Role names starting with "pg_" are reserved.
Time: 3.651 ms
```

I would propose to change it to `postgres_extensions` ( password as well)
I now that the plugin target postgresql `9.4` but this makes it at least forward compatible.